### PR TITLE
fix wrong sudoers line and test call in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Attack! solves this problem.
       (www-data by default) needs to be able to execute sudo commands without
       entering a password.
 
-      E.g. in /etc/sudoers: `www-data ALL=(ALL) NOPASSED: ALL`
+      E.g. in /etc/sudoers: `www-data ALL=(ALL) NOPASSWD: ALL`
+      Hint: use sudo visudo to edit sudoers file.
 
 
   2.  Modify your `COMMAND_SETS` in the `attack.py` script to define your 
@@ -29,7 +30,7 @@ Attack! solves this problem.
  
       You can test a set by calling attack.py with the target name. e.g.:  
 
-           python retaliation.py "[developer's user name]"
+           python attack.py "[developer's user name]"
 
       Trial and error is the best approach. Consider doing this secretly after
       hours for best results!


### PR DESCRIPTION
the sudoers line wrote "NOPASSED" on debian wheezy you need "NOPASSWD"

and added hint to use visudo for editing /etc/sudoers file since this has syntax checking.
